### PR TITLE
Fixed express dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {"node": ">=0.10.0"},
   "author": "Greg Stroup <gstroup@gmail.com>",
   "dependencies": {
-    "express": ">=3.1",
+    "express": "^3.1",
     "commander": ">=1",
     "underscore": ">=1"
   },


### PR DESCRIPTION
The current state of the apimocker library is not compatible with the
current 4.x versions of express. Restricted specified dependency
version range to versions compatible to 3.1.
