### PR TITLE
Added a configuration key to allow custom headers in CORS use case

### DIFF
--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -8,6 +8,7 @@ apiMocker.defaults = {
 	"port": "8888",
 	"mockDirectory": "./mocks/",
 	"allowedDomains": ["*"],
+	"allowedHeaders": ["Content-Type"],
 	"webServices": {}
 };
 
@@ -232,9 +233,11 @@ apiMocker.removeRoute = function(options) {
 
 // CORS middleware
 apiMocker.corsMiddleware = function(req, res, next) {
+  var allowedHeaders = apimocker.options.allowedHeaders.reduce(function(a, b){return a + ',' + b;});
+
   res.header('Access-Control-Allow-Origin', apiMocker.options.allowedDomains);
   res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
-  res.header('Access-Control-Allow-Headers', 'Content-Type');
+  res.header('Access-Control-Allow-Headers', allowedHeaders);
 
   next();
 };


### PR DESCRIPTION
Hi,
First thank you for this awesome mock server. Here is a PR to add support for custom allowed headers when doing CORS. 
I added a configuration key in config.json which is called "allowedHeaders" and which is by default set to ["Content-Type"].
Please tell me if you are seeing room for improvement in my implementation. 

Thanks again for your initial work ! 
