### PR TITLE
- added support of special characters in switch argument, fixed small typo in switched file naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ In your configuration, you can set up a "switch" parameter for each service.  If
   "customerId": 1234
 }
 ```
-will return data from the mock file called "customerId1234ace.json".  Switch values can also be passed in as query parameters:
+will return data from the mock file called "customerId1234.ace.json".  Switch values can also be passed in as query parameters:
         http://localhost:7878/nested/ace?customerId=1234
 or as part of the URL, if you have configured your service to handle variables, like the "var/:id" service above:
         http://localhost:7878/var/789
-If the specific file, such as "customerId1234ace.json" is not found, then apimocker will attempt to return the base file: "ace.json".
+If the specific file, such as "customerId1234.ace.json" is not found, then apimocker will attempt to return the base file: "ace.json".
 
 ## Runtime configuration
 After starting apimocker, mocks can be configured using a simple http api.

--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -175,7 +175,7 @@ apiMocker.sendResponse = function(req, res, options) {
 			res.status(options.httpStatus).send(buff);
 		});
 	} else {
-		res.status(options.httpStatus).sendfile(options.mockFile, {root: apiMocker.options.mockDirectory});
+		res.status(options.httpStatus).sendfile(encodeURIComponent(options.mockFile), {root: apiMocker.options.mockDirectory});
 	}
 };
 
@@ -194,7 +194,7 @@ apiMocker.setMockFile = function(options, req) {
 	if (mockFileParts.length > 0) {
 		mockFilePrefix = mockFileParts.join("/") + "/";
 	}
-	options.mockFile = mockFilePrefix + options.switch + switchValue + "." + mockFileBaseName;
+	options.mockFile = encodeURIComponent(mockFilePrefix + options.switch + switchValue) + "." + mockFileBaseName;
 };
 
 // Sets the route for express, in case it was not set yet.


### PR DESCRIPTION
 This fix corrent issue when you have special characters in your switch value that could not be repesented as a file. ([swith][value].[mockFile])

``` json
"webServers" : {
   "some/url" : {
      "mockFile" : "file.json",
      "verbs" : ["get"],
      "switch": "path"
   }
}
```

with following URI:

``` url
http://somehost/some/url?path=/
```

will now try to search for "path2%F.file.json" instead of "path/.file.json"
