### PR TITLE
Add JsonPath support to api mocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,19 @@ See the sample config.json file in this package.
         "userIduser1passwordgood": {"httpStatus": 200, "mockFile": "king.json"},
         "userIdadminpasswordgood": {"httpStatus": 200}
       }
-    }
+    },
+   "nested/aceinsleeve": {
+      "verbs": [
+        "post"
+      ],
+      "switch": "$..ItemId[(@.length-1)]",
+      "responses": {
+        "post": {"httpStatus": 200, "mockFile": "aceinsleeve.json"}
+      },	
+      "switchResponses": {
+        "$..ItemId[(@.length-1)]4": {"httpStatus": 500, "mockFile": "ItemId4.aceinsleeve.json"}
+      }
+   }
   }
 }
 ```
@@ -150,6 +162,21 @@ To specify a different HTTP status, depending on a request parameter, you'll nee
 ```
 will return data from the mock file called "king.json", with HTTP status 200.
 Any other password will return "sorry.json" with HTTP status 401.
+
+### JsonPath Support
+For complex json requests, JsonPath expressions are supported in the switch parameter. For example to switch the response based on the value of the last occurance
+of ItemId in a json request, use  configuration as shows for "aceinsleeve":
+```js
+"switch": "$..ItemId[(@.length-1)]",
+  "responses": {
+    "post": {"httpStatus": 200, "mockFile": "aceinsleeve.json"}
+  },	
+  "switchResponses": {
+    "$..ItemId[(@.length-1)]4": {"httpStatus": 500, "mockFile": "ItemId4.aceinsleeve.json"}
+  }
+```
+According to this configuration, if the value of the last occurance of ItemId is 4, the mockFile "ItemId4.aceinsleeve.json" will be retured with a HTTP status code of 500. Otherwise, mockFile "aceinsleeve.json"
+will be returned with HTTP status 200. Note: If the JsonPath expression evaluates to more then 1 element (for example, all books cheaper than 10 as in $.store.book[?(@.price < 10)] ) then the first element is considered for testing the value.
 
 ## Runtime configuration
 After starting apimocker, mocks can be configured using a simple http api.

--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -3,7 +3,8 @@ var express = require('express'),
     path = require("path"),
     fs = require("fs"),
     bodyParser = require("body-parser"),
-    apiMocker = {};
+    apiMocker = {},
+    jsonPath = require('JSONPath');
 
 apiMocker.defaults = {
   "port": "8888",
@@ -209,6 +210,15 @@ apiMocker.setSwitchOptions = function(options, req) {
     } else if (req.param(s)) { // query param in get request
       switchParamValue = encodeURIComponent( req.param(s));
     }
+	
+    if(!switchParamValue && (s.indexOf("$.") == 0)){
+      //use JsonPath - use first value found if multiple occurances exist
+      var allElems=jsonPath.eval(req.body, s);
+      if(allElems.length>0){
+        switchParamValue = encodeURIComponent(allElems[0]);
+      }
+    }
+	
     if (switchParamValue) {
       switchFilePrefix = switchFilePrefix + s + switchParamValue;
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "body-parser": "~1.4.3",
     "commander": ">=1",
     "express": "~4.5",
-    "underscore": ">=1"
+    "underscore": ">=1",
+	"jsonpath": ">=1.4.28"
   },
   "devDependencies": {
     "mocha": ">=1.8.2",


### PR DESCRIPTION
Greg,
Here are my changes for JsonPath support. We have complex json requests and having this json path support will help us with mocking requests with different values of specific elements in the request. I hope this will benefit other users as well.
thanks
priya
