### PR TITLE
Adding an option to log request headers when a request comes in

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
   "quiet": false,
   "port": "7878",
   "latency": 50,
+  "logRequestHeaders": false,
   "webServices": {
     "first": {
       "mockFile": "foo.json",

--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -12,6 +12,7 @@ apiMocker.defaults = {
   "mockDirectory": "./mocks/",
   "allowedDomains": ["*"],
   "allowedHeaders": ["Content-Type"],
+  "logRequestHeaders": false,
   "webServices": {}
 };
 
@@ -25,7 +26,6 @@ apiMocker.createServer = function(options) {
   // new in Express 4, we use a Router now.
   apiMocker.router = express.Router();
   apiMocker.express.use(apiMocker.router);
-
 
   apiMocker.options = _.defaults(options, apiMocker.defaults);
 
@@ -160,6 +160,11 @@ apiMocker.sendResponse = function(req, res, serviceKeys) {
     mockPath = path.join(apiMocker.options.mockDirectory, options.mockFile);
     apiMocker.log("Returning mock: " + options.verb.toUpperCase() + " " + options.serviceUrl + " : " +
         options.mockFile);
+
+    if(apiMocker.options.logRequestHeaders) {
+      apiMocker.log("Request headers:");
+      apiMocker.log(req.headers);  
+    }
 
     if (options.headers) {
         res.header(options.headers);

--- a/test/test.js
+++ b/test/test.js
@@ -15,6 +15,7 @@ describe('unit tests: ', function() {
           "quiet": true,
           "port": "7879",
           "latency": 50,
+          "logRequestHeaders": true,
           "allowedDomains": ["abc"],
           "allowedHeaders": ["my-custom1", "my-custom2"],
           "webServices": {
@@ -54,6 +55,7 @@ describe('unit tests: ', function() {
       expect(mocker.options.allowedDomains[0]).to.equal("*");
       expect(mocker.options.allowedHeaders[0]).to.equal("Content-Type");
       expect(mocker.options.quiet).to.equal(undefined);
+      expect(mocker.options.logRequestHeaders).to.equal(false);
     });
 
     it('overrides defaults with command line args', function() {
@@ -115,17 +117,19 @@ describe('unit tests: ', function() {
       expect(mocker.options.webServices).to.deep.equal(testConfig.webServices);
       expect(mocker.options.quiet).to.equal(true);
       expect(mocker.options.latency).to.equal(testConfig.latency);
+      expect(mocker.options.logRequestHeaders).to.equal(testConfig.logRequestHeaders);
     });
 
     it("combines values from defaults, options, and config file", function() {
       var mocker = apiMocker.createServer({quiet: true, test: "fun", port: 2323});
-      fsStub.returns(JSON.stringify({port: 8765, latency: 99}));
+      fsStub.returns(JSON.stringify({port: 8765, latency: 99, logRequestHeaders: false}));
       mocker = mocker.setConfigFile("another abitrary value");
 
       mocker.loadConfigFile();
       // value from config file
       expect(mocker.options.port).to.equal(8765);
       expect(mocker.options.latency).to.equal(99);
+      expect(mocker.options.logRequestHeaders).to.equal(false);
       // value from defaults
       expect(mocker.options.allowedDomains[0]).to.equal("*");
       expect(mocker.options.webServices).to.deep.equal(mocker.defaults.webServices);


### PR DESCRIPTION
Adds an option where the request headers are logged to the console when a new request comes in.

Background:
I was using API mocker in a scenario where an application I'm developing is calling the mocked API. The application adds a few extra headers (one custom and an authorization header). By default the log only displays that it is returning a mock, making it a bit hard to see if the headers were correctly added. 