### PR TITLE
Add ability to specify alternate URL paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ See the sample config.json file in this package.
 * A static route can be opened up to serve up static assets like images.  Both staticDirectory and staticPath must be set.  If either is not set, then nothing happens.
 * Additional headers can be defined for responses.
 * Request headers can be logged, with the `logRequestHeaders` setting.
+* Alternate URL paths can be specified with the `alternatePaths` setting.
 
 ```js
 {
@@ -79,7 +80,8 @@ See the sample config.json file in this package.
     "first": {
       "mockFile": "king.json",
       "latency": 20,
-      "verbs": ["get"]
+      "verbs": ["get"],
+      "alternatePaths": ["1st"]
     },
     "second": {
       "verbs": ["delete", "post"],
@@ -133,7 +135,7 @@ See the sample config.json file in this package.
       "mockFile": "king.json",
       "contentType": "foobar",
       "headers": {
-        "x-requested-by": "4c2df03a17a803c063f21aa86a36f6f55bdde1f85b89e49ee1b383f281d18c09c2ba30654090df3531cd2318e3c", 
+        "x-requested-by": "4c2df03a17a803c063f21aa86a36f6f55bdde1f85b89e49ee1b383f281d18c09c2ba30654090df3531cd2318e3c",
         "dummyheader": "dummyvalue"
       },
       "verbs": ["get"]
@@ -188,7 +190,7 @@ For example to switch the response based on the value of the last occurence of I
 "switch": "$..ItemId[(@.length-1)]",
   "responses": {
     "post": {"httpStatus": 200, "mockFile": "aceinsleeve.json"}
-  },	
+  },
   "switchResponses": {
     "$..ItemId[(@.length-1)]4": {"httpStatus": 500, "mockFile": "ItemId4.aceinsleeve.json"}
   }
@@ -203,7 +205,7 @@ To return additional custom headers in the response, set the headers map in the 
       "mockFile": "king.json",
       "contentType": "foobar",
       "headers": {
-        "x-requested-by": "4c2df03a17a803c063f21aa86a36f6f55bdde1f85b89e49ee1b383f281d18c09c2ba30654090df3531cd2318e3c", 
+        "x-requested-by": "4c2df03a17a803c063f21aa86a36f6f55bdde1f85b89e49ee1b383f281d18c09c2ba30654090df3531cd2318e3c",
         "dummyheader": "dummyvalue"
       },
       "verbs": ["get"]

--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -63,6 +63,14 @@ apiMocker.loadConfigFile = function() {
     newOptions = _.extend(newOptions, apiMocker.options, configJson);
     newOptions.mockDirectory = untildify(newOptions.mockDirectory);
     apiMocker.options = newOptions;
+
+    _.each(apiMocker.options.webServices, function (svc) {
+      _.each(svc.alternatePaths, function (path) {
+        var altSvc = _.clone(svc);
+        apiMocker.options.webServices[path] = altSvc;
+      });
+    });
+
     apiMocker.setRoutes(apiMocker.options.webServices);
   } else {
     apiMocker.log("No config file path set.");
@@ -167,13 +175,13 @@ apiMocker.sendResponse = function(req, res, serviceKeys) {
 
     if(apiMocker.options.logRequestHeaders) {
       apiMocker.log("Request headers:");
-      apiMocker.log(req.headers);  
+      apiMocker.log(req.headers);
     }
 
     if (options.headers) {
         res.header(options.headers);
     }
-    
+
     if (options.contentType) {
       res.header('Content-Type', options.contentType);
       fs.readFile(mockPath, {encoding: "utf8"}, function(err, data) {

--- a/test/test-config.json
+++ b/test/test-config.json
@@ -9,7 +9,8 @@
     "first": {
       "mockFile": "king.json",
       "contentType": "foobar",
-      "verbs": ["get"]
+      "verbs": ["get"],
+      "alternatePaths": ["1st"]
     },
     "second": {
       "verbs": ["delete"],
@@ -55,7 +56,7 @@
       "mockFile": "king.json",
       "contentType": "foobar",
       "headers": {
-        "x-requested-by": "4c2df03a17a803c063f21aa86a36f6f55bdde1f85b89e49ee1b383f281d18c09c2ba30654090df3531cd2318e3c", 
+        "x-requested-by": "4c2df03a17a803c063f21aa86a36f6f55bdde1f85b89e49ee1b383f281d18c09c2ba30654090df3531cd2318e3c",
         "dummyheader": "dummyvalue"
       },
       "verbs": ["get"]

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -116,6 +116,11 @@ describe('Functional tests using an http client to test "end-to-end": ', functio
         var reqOptions = httpReqOptions("/noMockFile");
         verifyResponseBody(reqOptions, null, {"apimockerError": "No mockFile was configured for route.  Check apimocker config.json file.", "route": "noMockFile"}, done);
       });
+
+      it('returns correct data for an alternate path', function (done) {
+        var reqOptions = httpReqOptions("/1st");
+        verifyResponseBody(reqOptions, null, {"king": "greg"}, done);
+      });
     });
 
     describe('content type: ', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -28,7 +28,8 @@ describe('unit tests: ', function() {
                 "post": {
                   "mockFile": "ace.json"
                 }
-              }
+              },
+              "alternatePaths": ["1st"]
             },
             "nested/ace": {
               "mockFile": "ace.json",
@@ -114,7 +115,12 @@ describe('unit tests: ', function() {
       expect(mocker.options.allowedDomains[0]).to.equal(testConfig.allowedDomains[0]);
       expect(mocker.options.allowedHeaders[0]).to.equal("my-custom1");
       expect(mocker.options.allowedHeaders[1]).to.equal("my-custom2");
+
+      expect(mocker.options.webServices.first)
+        .to.eql(mocker.options.webServices["1st"]);
+      delete mocker.options.webServices["1st"];
       expect(mocker.options.webServices).to.deep.equal(testConfig.webServices);
+
       expect(mocker.options.quiet).to.equal(true);
       expect(mocker.options.latency).to.equal(testConfig.latency);
       expect(mocker.options.logRequestHeaders).to.equal(testConfig.logRequestHeaders);


### PR DESCRIPTION
I have a need to support multiple paths/aliases for any given end point. The only way I can currently do this is by duplicating my config.
This PR suggests a way to specify alternate paths for a webservice e.g.
```
"first": {
  "verbs": ["get"],
  "mockFile": "data.json",
  "alternatePaths": ["1st"]
}
```
would mean `/first` and `/1st` respond with the same data.