### PR TITLE
Added ability to switch on header param

### DIFF
--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -212,6 +212,8 @@ apiMocker.setSwitchOptions = function(options, req) {
       switchParamValue = encodeURIComponent( req.body[s] );
     } else if (req.param(s)) { // query param in get request
       switchParamValue = encodeURIComponent( req.param(s));
+    } else if (req.headers && req.headers[s.toLowerCase()]) { // header param
+      switchParamValue = encodeURIComponent(req.headers[s.toLowerCase()]);
     }
 
     if(!switchParamValue && (s.indexOf("$.") === 0)){


### PR DESCRIPTION
My requirement was to switch on a header param, e.g.

```json
"first": {
      "verbs": ["get", "post"],
      "responses": {
          "get": {"mockFile": "Default.xml"},
          "post": {"mockFile": "Default.xml"}
      },
      "switch": ["SOAPAction"],
      "switchResponses": {
          "http://tempuri.org/GetCustomers": {"httpStatus": 200, "mockFile": "GetCustomers.xml"},
          "http://tempuri.org/GetInventory": {"httpStatus": 200, "mockFile": "GetInventory.xml"}
      }
}
```