### PR TITLE
Add proxy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ That will install globally, and allow for easier usage.
 (On Windows, you don't need "sudo".)
 
 ## Usage
-        apimocker [-c, --config \<path\>] [-q, --quiet] [-p \<port\>]
+        apimocker [-c, --config \<path\>] [-q, --quiet] [-p \<port\>] [-f, --proxy \<proxyURL\>]
 
 Out of the box, you can just run "apimocker" with no arguments.
 (Except on windows, you'll need to edit config.json first.  See below.)
@@ -28,6 +28,11 @@ After you get up and running, you should put your config.json and mock responses
 It's not a good idea to keep them under the "node_modules" directory.
 Make sure another process is not already using the port you want.
 If you want port 80, you may need to use "sudo" on Mac OSX.
+
+### proxy
+For when you only want some service endpoints to be mocked, but have other endpoints forwarded to a real service.
+Provide the proxy option on startup e.g.
+`apimocker --proxy http://myrealservice.io`
 
 ### With Grunt or Gulp
 If you're using Grunt for your project, there's a grunt plugin you can use to start up apimocker:

--- a/bin/apimocker.js
+++ b/bin/apimocker.js
@@ -8,11 +8,13 @@ commander
     .option("-c, --config <path>", "Path to config.json file.", __dirname + "/../config.json")
     .option("-q, --quiet", "Disable console logging")
     .option("-p, --port <port>", "Port that the http mock server will use. Default is 8888.", "8888")
+    .option("-f, --proxy <proxyURL>", "URL of a service to proxy to when for endpoints that are not mocked", false)
     .parse(process.argv);
 
 var options = {};
 options.port = commander.port;
 options.quiet = !!commander.quiet;
+options.proxyURL = commander.proxy;
 
 var apiMocker = ApiMocker.createServer(options)
     .setConfigFile(commander.config)

--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -6,7 +6,8 @@ var express = require('express'),
     apiMocker = {},
     jsonPath = require('JSONPath'),
     untildify = require('untildify'),
-    util = require('util');
+    util = require('util'),
+    proxy = require('express-http-proxy');
 
 apiMocker.defaults = {
   "port": "8888",
@@ -27,6 +28,15 @@ apiMocker.createServer = function(options) {
   // new in Express 4, we use a Router now.
   apiMocker.router = express.Router();
   apiMocker.express.use(apiMocker.router);
+
+  if (options.proxyURL) {
+    apiMocker.express.use("*", proxy(options.proxyURL, {
+      forwardPath: function (req, res) {
+        apiMocker.log("Forwarding request: " + req.originalUrl);
+        return req.originalUrl;
+      }
+    }));
+  }
 
   apiMocker.options = _.defaults(options, apiMocker.defaults);
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "body-parser": "~1.4.3",
     "commander": ">=1",
     "express": "~4.5",
+    "express-http-proxy": "0.6.0",
     "underscore": ">=1",
     "untildify": "^2.0.0"
   },


### PR DESCRIPTION
This adds a basic proxying capability, leveraging `express-http-proxy`. This is integrated using a catch all express route.

Resolves https://github.com/gstroup/apimocker/issues/35

I had to add some 404 handling in the functional test proxy to make a test pass. I played around with putting the proxy tests in a separate file, but decided it was better to have the test proxy enabled for all functional tests. That way we can have better confidence it won't break existing functionality.

I did some additional testing in a real use case where I needed the proxy function, and it worked well.
