### PR TITLE
Add support for flexible 'templateSwitch' request/response substitution

### DIFF
--- a/config.json
+++ b/config.json
@@ -62,6 +62,32 @@
         "enableTemplate": true,  
 	"verbs":["get"], 
 	"contentType":"application/json"
+    },
+    "templateSwitchGetParams" : {
+      "mockFile": "templateSwitchSample.json",
+      "verbs":["get"],
+      "templateSwitch": ["appID",
+                         "appName",
+                         "userName",
+                         "userAge"],
+      "contentType": "application/json"
+    },
+    "templateSwitchPostJsonPath" : {
+      "mockFile": "templateSwitchSample.json",
+      "verbs": ["post"],
+      "templateSwitch": [{"key": "appID",
+                         "switch": "$.data.appID",
+                         "type": "jsonpath"},
+                         {"key": "appName",
+                          "switch": "$.data.appName",
+                          "type": "jsonpath"},
+                         {"key": "userName",
+                          "switch": "$.data.user.userName",
+                          "type": "jsonpath"},
+                         {"key": "userAge",
+                          "switch": "$.data.user.userAge",
+                          "type": "jsonpath"}],
+      "contentType": "application/json"
     }
   }
 }

--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -246,7 +246,7 @@ apiMocker.sendResponse = function(req, res, serviceKeys) {
       fs.readFile(mockPath, {encoding: "utf8"}, function(err, data) {
         if (err) { throw err; }
 
-        if(options.templateSwitch === true){
+        if(options.templateSwitch){
           data = apiMocker.fillTemplateSwitch(options, data, req);
         }
 

--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -178,7 +178,7 @@ apiMocker.fillTemplateSwitch = function(options, data, req){
       value = s.value;
     }
 
-    if(typeof value != null)
+    if(typeof value !== null)
     {
       apiMocker.log("fillTemplateSwitch -> search for @" + key + " replace with " + value);
       data = data.replace(new RegExp("@"+key,'g'), value);
@@ -474,8 +474,8 @@ apiMocker.setTemplateSwitchOptions = function(options, req) {
     }
 
     if (switchParamValue) {
-      switchObject.value = switchParamValue
-      options.templateSwitch[s] = switchObject
+      switchObject.value = switchParamValue;
+      options.templateSwitch[s] = switchObject;
     }
     else {
       apiMocker.log("templateSwitch[" + switchObject.switch + "] value NOT FOUND");

--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -160,7 +160,38 @@ apiMocker.fillTemplate = function(data, req){
 	} 
 
 	return data; 
-}; 
+};
+
+apiMocker.fillTemplateSwitch = function(options, data, req){
+  var switches = options.templateSwitch;
+
+  switches.forEach(function(s){
+    var key, value;
+
+    if (!(s instanceof Object)) {
+      key = switches[s].key;
+      value = switches[s].value;
+    }
+    else
+    {
+      key = s.key;
+      value = s.value;
+    }
+
+    if(typeof value != null)
+    {
+      apiMocker.log("fillTemplateSwitch -> search for @" + key + " replace with " + value);
+      data = data.replace(new RegExp("@"+key,'g'), value);
+    }
+    else
+    {
+      apiMocker.log("fillTemplateSwitch -> skipping search for @" + key + " with no value.");
+    }
+
+  });
+
+  return data;
+};
 
 apiMocker.sendResponse = function(req, res, serviceKeys) {
   var originalOptions, mockPath;
@@ -187,6 +218,10 @@ apiMocker.sendResponse = function(req, res, serviceKeys) {
       }
     }
 
+    if (options.templateSwitch) {
+      apiMocker.setTemplateSwitchOptions(options, req);
+    }
+
     if (!options.mockFile) {
       apiMocker.log("ERROR: No mockFile was configured for route: " + options.serviceUrl);
       res.status(500).send({ apimockerError: 'No mockFile was configured for route.  Check apimocker config.json file.', route: options.serviceUrl });
@@ -211,10 +246,14 @@ apiMocker.sendResponse = function(req, res, serviceKeys) {
       fs.readFile(mockPath, {encoding: "utf8"}, function(err, data) {
         if (err) { throw err; }
 
-	if(options.enableTemplate === true){
-		data = apiMocker.fillTemplate(data, req); 
-	}
-	
+        if(options.templateSwitch){
+          data = apiMocker.fillTemplateSwitch(options, data, req);
+        }
+
+        if(options.enableTemplate === true){
+          data = apiMocker.fillTemplate(data, req);
+        }
+
         var buff = new Buffer(data, 'utf8');
 	
         res.status(options.httpStatus).send(buff);
@@ -341,6 +380,109 @@ apiMocker.setSwitchOptions = function(options, req) {
   }
   options.mockFile = mockFilePrefix + switchFilePrefix + "." + mockFileBaseName;
 };
+
+
+// only used when there is a templateSwitch configured
+apiMocker.setTemplateSwitchOptions = function(options, req) {
+  var switchParamValue;
+
+  var switches = options.templateSwitch;
+  if(!(switches instanceof Array)){
+    switches = [switches];
+  }
+
+  switches.forEach(function(s){
+    switchParamValue = null;
+    var switchObject = s,
+    specific = true;
+
+    if (!(s instanceof Object)) {
+      // The user didn't configure a switch object. Make one.
+      switchObject = {
+        key: s,
+        switch: s,
+        type: "default",
+        value: null
+      };
+
+      if (s.match(/\/(.+)\//)) {
+        switchObject.type = "regexp";
+      } else if (s.indexOf("$") === 0) {
+        switchObject.type = "jsonpath";
+      }
+
+      // As we had no switch object, we have to test default-type first to
+      // mimic the old behaviour.
+      specific = false;
+    }
+
+    if (!switchObject.hasOwnProperty("key")) {
+      // Add key if the user was too lazy
+      switchObject.key = switchObject.switch;
+    }
+
+    // Sanity check the switchobject
+    if (
+       !switchObject.hasOwnProperty("switch") ||
+       !switchObject.hasOwnProperty("type") ||
+       !switchObject.hasOwnProperty("key")
+       ) {
+      apiMocker.log("templateSwitch invalid config: missing switch, type or key property. Aborting templateSwitch for this request.");
+      return;
+    }
+
+    if (!specific || switchObject.type === "default") {
+      if (req.body[switchObject.switch]) { // json post request
+        switchParamValue = encodeURIComponent( req.body[switchObject.switch] );
+      } else if (req.param(switchObject.switch)) { // query param in get request
+        switchParamValue = encodeURIComponent( req.param(switchObject.switch));
+      } else if (req.headers) { // check for switch in header param
+        for (var h in req.headers) {
+          if (req.headers.hasOwnProperty(h) && h.toLowerCase() === switchObject.switch.toLowerCase()) {
+            switchParamValue = encodeURIComponent(req.headers[h]);
+            break;
+          }
+        }
+      }
+
+    }
+
+    if (!switchParamValue) {
+      if (switchObject.type === "regexp") {
+        var regexpTest = switchObject.switch.match(/\/(.+)\//);
+        if (regexpTest) { // A regexp switch
+          var searchBody = req.body;
+
+          if (typeof(req.body) !== "string") {
+            // We don't have a body string, parse it in JSON
+            searchBody = JSON.stringify(req.body);
+          }
+
+          var regexpSwitch = new RegExp(regexpTest[1]).exec(searchBody);
+          if (regexpSwitch) {
+            // Value is the first group
+            switchParamValue = encodeURIComponent(regexpSwitch[1]);
+          }
+        }
+      } else {
+        //use JsonPath - use first value found if multiple occurances exist
+        var allElems = jsonPath.eval(req.body, switchObject.switch);  // jshint ignore:line
+        if (allElems.length > 0) {
+          switchParamValue = encodeURIComponent(allElems[0]);
+        }
+      }
+    }
+
+    if (switchParamValue) {
+      switchObject.value = switchParamValue
+      options.templateSwitch[s] = switchObject
+    }
+    else {
+      apiMocker.log("templateSwitch[" + switchObject.switch + "] value NOT FOUND");
+    }
+  });
+};
+
 
 // Sets the route for express, in case it was not set yet.
 apiMocker.setRoute = function(options) {

--- a/samplemocks/templateSwitchSample.json
+++ b/samplemocks/templateSwitchSample.json
@@ -1,0 +1,6 @@
+{
+    "appID": @appID,
+    "appName": "@appName",
+    "userName": "@userName",
+    "userAge": @userAge
+}

--- a/test/test-config.json
+++ b/test/test-config.json
@@ -69,6 +69,32 @@
       "enableTemplate" : true, 
       "contentType": "application/json", 
       "verbs": ["get"]
+    },
+    "templateSwitchGetParams" : {
+      "mockFile": "templateSwitchSample.json",
+      "verbs":["get"],
+      "templateSwitch": ["appID",
+                         "appName",
+                         "userName",
+                         "userAge"],
+      "contentType": "application/json"
+    },
+    "templateSwitchPostJsonPath" : {
+      "mockFile": "templateSwitchSample.json",
+      "verbs": ["post"],
+      "templateSwitch": [{"key": "appID",
+                         "switch": "$.data.appID",
+                         "type": "jsonpath"},
+                         {"key": "appName",
+                          "switch": "$.data.appName",
+                          "type": "jsonpath"},
+                         {"key": "userName",
+                          "switch": "$.data.user.userName",
+                          "type": "jsonpath"},
+                         {"key": "userAge",
+                          "switch": "$.data.user.userAge",
+                          "type": "jsonpath"}],
+      "contentType": "application/json"
     }
   }
 }

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -123,6 +123,28 @@ describe('Functional tests using an http client to test "end-to-end": ', functio
         verifyResponseBody(reqOptions, null, {"name":"john", "number":4}, done);
       });
 
+      it('returns correct data for get to templateSwitch substituting GET params into mockFile ', function(done) {
+        var reqOptions = httpReqOptions("/templateSwitchGetParams?appID=123456789&appName=myAppName&userName=MyName&userAge=21");
+        var expected = {"appID": 123456789,
+                        "appName": "myAppName",
+                        "userName": "MyName",
+                        "userAge": 21
+                       };
+        verifyResponseBody(reqOptions, null, expected, done);
+      });
+
+
+      it('returns correct data for post to templateSwitch substituting POST data parsed using jsonPath into mockFile', function(done) {
+        var postData = '{ "data": { "appID": 123456789, "appName": "myAppName", "user": { "userName": "MyName", "userAge": 21 } } }',
+            postOptions =  httpPostOptions("/templateSwitchPostJsonPath", postData),
+            expected = {"appID": 123456789,
+                        "appName": "myAppName",
+                        "userName": "MyName",
+                        "userAge": 21
+                       };
+        verifyResponseBody(postOptions, postData, expected, done);
+      });
+
       it('returns correct data for an alternate path', function (done) {
         var reqOptions = httpReqOptions("/1st");
         verifyResponseBody(reqOptions, null, {"king": "greg"}, done);


### PR DESCRIPTION
borrowing heavily from the 'switch' code, and the template concept I've enhanced this to support GET and POST support including POST BODY parameter matching with JSONPath.