### PR TITLE
Support 404 response on missing mockFile using switch

### DIFF
--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -260,10 +260,8 @@ apiMocker.sendResponse = function(req, res, serviceKeys) {
     }
 
     if (options.contentType) {
-      fs.access(mockPath, fs.F_OK, function(err) {
-        if (err) {
-          res.send(404)
-        } else {
+      fs.exists(mockPath, function(exists) {
+        if (exists) {
           res.header('Content-Type', options.contentType);
           fs.readFile(mockPath, {encoding: "utf8"}, function(err, data) {
             if (err) { throw err; }
@@ -280,6 +278,8 @@ apiMocker.sendResponse = function(req, res, serviceKeys) {
 
             res.status(options.httpStatus).send(buff);
           });
+        } else {
+          res.send(404)
         }
       });
     } else {

--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -260,21 +260,27 @@ apiMocker.sendResponse = function(req, res, serviceKeys) {
     }
 
     if (options.contentType) {
-      res.header('Content-Type', options.contentType);
-      fs.readFile(mockPath, {encoding: "utf8"}, function(err, data) {
-        if (err) { throw err; }
+      fs.access(mockPath, fs.F_OK, function(err) {
+        if (err) {
+          res.send(404)
+        } else {
+          res.header('Content-Type', options.contentType);
+          fs.readFile(mockPath, {encoding: "utf8"}, function(err, data) {
+            if (err) { throw err; }
 
-        if(options.templateSwitch){
-          data = apiMocker.fillTemplateSwitch(options, data, req);
+            if(options.templateSwitch){
+              data = apiMocker.fillTemplateSwitch(options, data, req);
+            }
+
+            if(options.enableTemplate === true){
+              data = apiMocker.fillTemplate(data, req);
+            }
+
+            var buff = new Buffer(data, 'utf8');
+
+            res.status(options.httpStatus).send(buff);
+          });
         }
-
-        if(options.enableTemplate === true){
-          data = apiMocker.fillTemplate(data, req);
-        }
-
-        var buff = new Buffer(data, 'utf8');
-	
-        res.status(options.httpStatus).send(buff);
       });
     } else {
       res.status(options.httpStatus).sendfile(encodeURIComponent(options.mockFile), {root: apiMocker.options.mockDirectory});


### PR DESCRIPTION
A typical behaviour of REST servers is to return a not found state for unknown ids. This is currently hard to configure. By configuring a non existing base file for a web service with a switch (but of course with matching mock files for some switch values) the service returns a simple 404 in a non matching switch instead of throwing an error.