### PR TITLE
Fixed an issue causing httpStatus to be ignored

### DIFF
--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -263,9 +263,9 @@ apiMocker.sendResponse = function(req, res, serviceKeys) {
 		apiMocker.log('Returning mock: ' + options.verb.toUpperCase() + ' ' + options.serviceUrl + ' : ' +
 				options.mockFile);
 
-		if (options.contentType) {
-			fs.exists(mockPath, function(exists) {
-				if (exists) {
+		fs.exists(mockPath, function(exists) {
+			if (exists) {
+				if (options.contentType) {
 					res.header('Content-Type', options.contentType);
 					fs.readFile(mockPath, {encoding: 'utf8'}, function(err, data) {
 						if (err) { throw err; }
@@ -283,13 +283,12 @@ apiMocker.sendResponse = function(req, res, serviceKeys) {
 						res.status(options.httpStatus || 200).send(buff);
 					});
 				} else {
-					res.send(options.httpStatus || 404);
+					res.status(options.httpStatus || 200).sendfile(encodeURIComponent(options.mockFile), {root: apiMocker.options.mockDirectory});
 				}
-			});
-		} else {
-			res.status(options.httpStatus || 200).sendfile(encodeURIComponent(options.mockFile), {root: apiMocker.options.mockDirectory});
-		}
-
+			} else {
+				res.send(options.httpStatus || 404);
+			}
+		});
 	}, options.latency);
 };
 


### PR DESCRIPTION
When the configuration does not provide a contentType, apimocker will `sendfile` without caring if the file is there or not ignoring the `httpStatus` parameter.