### PR TITLE
Allow HTTP status to be updated from /admin/setMock

### DIFF
--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -30,7 +30,7 @@ apiMocker.createServer = function(options) {
 				console.log(msg);
 			}
 		}
-	};
+	}
 
 	apiMocker.express = express();
 	apiMocker.middlewares = [];
@@ -139,12 +139,14 @@ apiMocker.createAdminServices = function() {
 			apiMocker.log('Received JSON request: ' + JSON.stringify(req.body));
 			newRoute = req.body;
 			newRoute.verb = newRoute.verb.toLowerCase();
+			newRoute.httpStatus = req.body.httpStatus;
 		} else {
 			newRoute.verb = req.param('verb').toLowerCase();
 			newRoute.serviceUrl = req.param('serviceUrl');
 			newRoute.mockFile = req.param('mockFile');
 			newRoute.latency = req.param('latency');
 			newRoute.contentType = req.param('contentType');
+			newRoute.httpStatus = req.param('httpStatus');
 		}
 		// also need to save in our webServices object.
 		delete apiMocker.options.webServices[newRoute.serviceUrl];

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -309,15 +309,16 @@ describe('Functional tests using an http client to test "end-to-end": ', functio
 		//	 req.end();
 		// }
 
-			var postData = {'verb':'get', 'serviceUrl':'third', 'mockFile':'king.json'},
-				postOptions =	httpPostOptions('/admin/setMock', postData),
-				expected = {
-					'verb':'get',
-					'serviceUrl':'third',
-					'mockFile':'king.json',
-					'httpStatus': 200
-				};
 			it('returns correct mock file after admin/setMock was called', function(done) {
+				var postData = {'verb':'get', 'serviceUrl':'third', 'mockFile':'king.json'},
+					postOptions =	httpPostOptions('/admin/setMock', postData),
+					expected = {
+						'verb':'get',
+						'serviceUrl':'third',
+						'mockFile':'king.json',
+						'httpStatus': 200
+					};
+
 				// verifyResponseBody(postOptions, postData, expected);
 				// verifyResponseBody(httpReqOptions('/third'), null, {king: 'greg'}, done);
 
@@ -327,6 +328,25 @@ describe('Functional tests using an http client to test "end-to-end": ', functio
 					.expect(200, function() {
 						stRequest.get('/third')
 							.expect(200, {king: 'greg'}, done);
+					});
+			});
+
+			it('returns correct mock file with http status code after admin/setMock was called', function(done) {
+				var postData = {'verb':'post', 'serviceUrl':'third', 'mockFile':'king.json', 'httpStatus': 201},
+					postOptions =	httpPostOptions('/admin/setMock', postData),
+					expected = {
+						'verb':'post',
+						'serviceUrl':'third',
+						'mockFile':'king.json',
+						'httpStatus': 201
+					};
+
+				stRequest.post('/admin/setMock')
+					.set('Content-Type', 'application/json')
+					.send(postData)
+					.expect(200, function() {
+						stRequest.post('/third')
+							.expect(201, {king: 'greg'}, done);
 					});
 			});
 


### PR DESCRIPTION
This parses `httpStatus` from the `setMock` parameters to allow changing it on the fly.