### PR TITLE
Parse Server support.

### DIFF
--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -16,6 +16,7 @@ apiMocker.defaults = {
 	'allowedDomains': ['*'],
 	'allowedHeaders': ['Content-Type'],
 	'logRequestHeaders': false,
+	'allowAvoidPreFlight': false,
 	'webServices': {}
 };
 
@@ -45,14 +46,23 @@ apiMocker.createServer = function(options) {
 		extended: true,
 		verify: saveBody
 	}));
-	apiMocker.middlewares.push(bodyParser.json({
-		verify: saveBody
-	}));
-	apiMocker.middlewares.push(bodyParser.json({
-		strict: false,
-		verify: saveBody,
-		type: 'text/plain'
-	}));
+
+	if (options.allowAvoidPreFlight) {
+
+		apiMocker.middlewares.push(bodyParser.json({
+			strict: false,
+			verify: saveBody,
+			type: '*/*'
+		}));
+
+	} else {
+
+		apiMocker.middlewares.push(bodyParser.json({
+			verify: saveBody
+		}));
+
+	}
+
 	apiMocker.middlewares.push(xmlparser());
 	apiMocker.middlewares.push(apiMocker.corsMiddleware);
 

--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -30,7 +30,7 @@ apiMocker.createServer = function(options) {
 				console.log(msg);
 			}
 		}
-	};
+	}
 
 	apiMocker.express = express();
 	apiMocker.middlewares = [];
@@ -47,6 +47,11 @@ apiMocker.createServer = function(options) {
 	}));
 	apiMocker.middlewares.push(bodyParser.json({
 		verify: saveBody
+	}));
+	apiMocker.middlewares.push(bodyParser.json({
+		strict: false,
+		verify: saveBody,
+		type: 'text/plain'
 	}));
 	apiMocker.middlewares.push(xmlparser());
 	apiMocker.middlewares.push(apiMocker.corsMiddleware);

--- a/test/test.js
+++ b/test/test.js
@@ -149,6 +149,21 @@ describe('unit tests: ', function() {
       mocker.loadConfigFile();
       expect(mocker.options.mockDirectory).to.equal(untildify(testConfig.mockDirectory));
     });
+
+    it("should not allow requests that avoid pre flight by default", function () {
+      var mocker = apiMocker.createServer({quiet: true});
+      expect(mocker.options.allowAvoidPreFlight).to.equal(false);
+    });
+
+    it("should allow requests that avoid pre flight if specified in config", function () {
+      var mocker = apiMocker.createServer({quiet: true});
+      fsStub.returns(JSON.stringify({
+        "allowAvoidPreFlight": true
+      }));
+      mocker.loadConfigFile();
+      expect(mocker.options.allowAvoidPreFlight).to.equal(true);
+    });
+
   });
 
   describe("setSwitchOptions: ", function() {


### PR DESCRIPTION
Some backend servers have SDKs that avoid pre-flight requests (ex: [Parse Server](https://github.com/parse-community/parse-server)). They are doing that by sending a `Content-Type: text/plain` even though the request is of type `application/json`.
This way of handling things makes the switch feature of apimocker unusable in those situations.

This fixes #77.

Changes:
 - Added support for requests that avoid pre-flight by sending `Content-Type: text/plain`
 - Removed a unnecessary colon.
 - Added `allowAvoidPreFlight` config option that once set to true will allow requests sent with `Content-Type: text/plain` to be processed as json if possible. The `allowAvoidPreFlight` is by default `false`.