### PR TITLE
Fix content type and other headers

### DIFF
--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -291,7 +291,7 @@ apiMocker.sendResponse = function(req, res, serviceKeys) {
 		}
 
 		if (options.headers) {
-			res.header(options.headers);
+			res.set(options.headers);
 		}
 
 		if (!options.mockFile) {
@@ -328,7 +328,7 @@ apiMocker.sendResponse = function(req, res, serviceKeys) {
 		fs.exists(mockPath, function(exists) {
 			if (exists) {
 				if (options.contentType) {
-					res.header('Content-Type', options.contentType);
+					res.set('Content-Type', options.contentType);
 					fs.readFile(mockPath, {encoding: 'utf8'}, function(err, data) {
 						if (err) { throw err; }
 
@@ -597,10 +597,10 @@ apiMocker.setRoute = function(options) {
 apiMocker.corsMiddleware = function(req, res, next) {
 	var allowedHeaders = apiMocker.options.allowedHeaders.join(',');
 	var credentials = apiMocker.options.corsCredentials || '';
-	res.header('Access-Control-Allow-Origin', apiMocker.options.allowedDomains);
-	res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,PATCH,DELETE');
-	res.header('Access-Control-Allow-Headers', allowedHeaders);
-	res.header('Access-Control-Allow-Credentials', credentials);
+	res.set('Access-Control-Allow-Origin', apiMocker.options.allowedDomains);
+	res.set('Access-Control-Allow-Methods', 'GET,PUT,POST,PATCH,DELETE');
+	res.set('Access-Control-Allow-Headers', allowedHeaders);
+	res.set('Access-Control-Allow-Credentials', credentials);
 
 	next();
 };


### PR DESCRIPTION
Express has changed its interface: http://expressjs.com/en/api.html#res.set
```
res.header()
```
is now
```
res.set()
```