### PR TITLE
Remove url decoding when sending mockFile

### DIFF
--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -345,7 +345,7 @@ apiMocker.sendResponse = function(req, res, serviceKeys) {
 						res.status(options.httpStatus || 200).send(buff);
 					});
 				} else {
-					res.status(options.httpStatus || 200).sendFile(decodeURIComponent(options.mockFile), {root: apiMocker.options.mockDirectory});
+					res.status(options.httpStatus || 200).sendFile(options.mockFile, {root: apiMocker.options.mockDirectory});
 				}
 			} else {
 				res.sendStatus(options.httpStatus || 404);


### PR DESCRIPTION
The encoding of the `mockFile` path changed between v.0.5.1 and v1.01 in this commit:
https://github.com/gstroup/apimocker/commit/a79387f295f158c25fc1a667b3a41dabb9168349

During `sendResponse`, a raw path is used to check if the path exists, while a decoded path is used to send the file. Mock files with URL encoded characters in their name would be found, but result in an error when being sent.  

For example, a mock switching on a `latLng` querystring parameter with a  value including`,`:
`/data/latLng47%2C-122.nearby.json`
The path will *not* be decoded to check the file exists--passing the `fs.exists` check. This was the previous, and expected behavior.
But a decoded path is then used to send the file:  
`/data/latLng47,-122.nearby.json`.

This results in:
```
Error: ENOENT: no such file or directory, stat '/data/latLng47,-122.3418.nearby.json'
    at Error (native)
```

This change removes the decoding when sending the file so the same path is used for both checking the existence of the file, and sending the file.