### PR TITLE
Fix retrieval of switch parameter in request

### DIFF
--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -354,6 +354,16 @@ apiMocker.sendResponse = function(req, res, serviceKeys) {
 	}, options.latency);
 };
 
+// Utility function to get a key's value from json body, route param, querystring, or header.
+const getRequestParam = (req, key) => {
+	const rawParamValue =
+		req.body[key] ||
+		req.params[key] ||
+		req.query[key] ||
+		req.header(key);
+	return rawParamValue;
+};
+
 // only used when there is a switch configured
 apiMocker.setSwitchOptions = function(options, req) {
 	var switchFilePrefix = '', switchParamValue,
@@ -403,17 +413,9 @@ apiMocker.setSwitchOptions = function(options, req) {
 		}
 
 		if (!specific || switchObject.type === 'default') {
-			if (req.body[switchObject.switch]) { // json post request
-				switchParamValue = encodeURIComponent( req.body[switchObject.switch] );
-			} else if (req.query && req.query[switchObject.switch]) { // query param in get request
-        switchParamValue = encodeURIComponent(req.query[switchObject.switch]);
-			} else if (req.headers) { // check for switch in header param
-				for (var h in req.headers) {
-					if (req.headers.hasOwnProperty(h) && h.toLowerCase() === switchObject.switch.toLowerCase()) {
-						switchParamValue = encodeURIComponent(req.headers[h]);
-						break;
-					}
-				}
+			const rawParamValue = getRequestParam(req, switchObject.switch);
+			if (rawParamValue) {
+				switchParamValue = encodeURIComponent(rawParamValue);
 			}
 		}
 
@@ -520,19 +522,10 @@ apiMocker.setTemplateSwitchOptions = function(options, req) {
 		}
 
 		if (!specific || switchObject.type === 'default') {
-			if (req.body[switchObject.switch]) { // json post request
-				switchParamValue = encodeURIComponent( req.body[switchObject.switch] );
-			} else if (req.query && req.query[switchObject.switch]) { // query param in get request
-				switchParamValue = encodeURIComponent( req.query[switchObject.switch]);
-			} else if (req.headers) { // check for switch in header param
-				for (var h in req.headers) {
-					if (req.headers.hasOwnProperty(h) && h.toLowerCase() === switchObject.switch.toLowerCase()) {
-						switchParamValue = encodeURIComponent(req.headers[h]);
-						break;
-					}
-				}
+			const rawParamValue = getRequestParam(req, switchObject.switch);
+			if (rawParamValue) {
+				switchParamValue = encodeURIComponent(rawParamValue);
 			}
-
 		}
 
 		if (!switchParamValue) {
@@ -584,7 +577,7 @@ apiMocker.setRoute = function(options) {
 			displayFile + ' ' + displayLatency);
 	if (options.switch) {
 		var switchDescription = options.switch;
-		if (options.switch instanceof Array || options.switch instanceof Object) {
+		if (options.switch instanceof Array || options.switch instanceof Object) {
 			switchDescription = util.inspect(options.switch);
 		}
 		apiMocker.log('	 with switch on param: ' + switchDescription);

--- a/test/test.js
+++ b/test/test.js
@@ -173,7 +173,10 @@ describe('unit tests: ', function() {
       mocker = apiMocker.createServer({quiet: true});
       svcOptions = {switch: "productId", mockFile: "base"};
       reqStub = {
-        body: {}
+        body: {},
+        params: {},
+        query: {},
+        header: () => {}
       };
     });
 
@@ -194,14 +197,20 @@ describe('unit tests: ', function() {
       expect(svcOptions.mockFile).to.equal("productId678.base");
     });
 
+    it("sets correct mock file path if switch is found in route parameter", function() {
+      reqStub.params = { productId: "123" };
+      mocker.setSwitchOptions(svcOptions, reqStub);
+      expect(svcOptions.mockFile).to.equal("productId123.base");
+    });
+
     it("sets correct mock file path if switch is found in request header with matching case", function() {
-      reqStub.headers = {productId: "765"};
+      reqStub.header = () => "765";
       mocker.setSwitchOptions(svcOptions, reqStub);
       expect(svcOptions.mockFile).to.equal("productId765.base");
     });
 
     it("sets correct mock file path if switch is found in request header with different case", function() {
-      reqStub.headers = {PRODUCTid: "765"};
+      reqStub.header = () => "765";
       svcOptions = {switch: "PRodUCTID", mockFile: "base"};
       mocker.setSwitchOptions(svcOptions, reqStub);
       expect(svcOptions.mockFile).to.equal("PRodUCTID765.base");


### PR DESCRIPTION
A recent change to how a switch value was accessed from a request introduced a regression bug: https://github.com/gstroup/apimocker/commit/5df065d0be7600a895e3a555fe7e6c918f9b8c44

That commit replaced the deprecated `req.param(key)` function in Express v3, which would get a parameter value from the route parameters, request  body, or querystring. It was replaced with `req.query`, which does not retrieve values from the route parameters (`req.params`). So mocked routes that used route params (e.g. `v2/position/:lang/:id`) would not return the file designated by the route parameter value (e.g. `v2/id376217.position.json`)

This PR uses a `getRequestParam` utility function to retrieve a switch value from the body, *route params*, querystring, or header. It fixes #91