### PR TITLE
Added direct body mock specification feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See the sample config.json file in this package.
 * With the `templateSwitch` setting, parameter names and values from the request can be mapped and inserted into the mock response, including POST requests and powerful JSONPath parameter substitution into a JSON POST body.
 * Set the `allowAvoidPreFlight` config option to true to allow requests sent with `Content-Type: text/plain` to be processed as json if possible. (default is false).  This allows apimocker to work with servers such as Parse Server.
 
-```js
+```json
 {
   "note": "This is a sample config file. You should change the mockDirectory to a more reasonable path.",
   "mockDirectory": "/usr/local/lib/node_modules/apimocker/samplemocks/",
@@ -165,13 +165,17 @@ See the sample config.json file in this package.
       "verbs":["get"],
       "enableTemplate": true,
       "contentType":"application/json"
+    },
+    "raw": {
+      "mockBody": "{ \"text\" : \"Good Job!\" }",
+      "verbs": ["all"]
     }
   }
 }
 ```
 The most interesting part of the configuration file is the webServices section.
-This section contains a JSON object describing each service.  The key for each service object is the service URL (endpoint.)  Inside each service object, the "mockFile" and "verbs" are required.  All other attributes of the service objects are optional.
-For instance, a GET request sent to "http://server:port/first" will return the king.json file from the samplemocks directory, with a 20 ms delay.
+This section contains a JSON object describing each service.  The key for each service object is the service URL (endpoint.)  Inside each service object, the `mockFile` (or `mockBody`) and `verbs` are required.  All other attributes of the service objects are optional.
+For instance, a GET request sent to "http://server:port/first" will return the king.json file from the samplemocks directory, with a 20 ms delay. Alternatively one can specify the `mockBody` firectly, bypassing the need for a specific mock file.
 If you'd like to return different responses for a single URL with different HTTP verbs ("get", "post", etc) then you'll need to add the "responses" object.  See above for the "second" service.  The "responses" object should contain keys for the HTTP verbs, and values describing the response for each verb.
 
 ### Switch response based on request parameter

--- a/config.json
+++ b/config.json
@@ -128,6 +128,15 @@
       "verbs": ["get"],
       "mockFile": "upload-form.html",
       "contentType": "text/html"
+    "raw": {
+      "mockBody": "{ \"text\" : \"Good Job!\" }",
+      "verbs": ["all"]
+    },
+    "raw/template/:message": {
+      "mockBody": "{ \"text\" : \"@message\" }",
+      "enableTemplate" : true,
+      "contentType": "application/json",
+      "verbs": ["get"]
     }
   }
 }

--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -314,17 +314,17 @@ apiMocker.sendResponse = (req, res, serviceKeys) => {
       res.set(options.headers);
     }
 
-    if (!options.mockFile && !options.mockBody) {
-      const status = options.httpStatus || 404;
-      res.status(status).send();
-      return;
-    }
-
     if (!!options.mockBody) {
       if (options.contentType) {
         res.set('Content-Type', options.contentType);
       };
       apiMocker.processTemplateData(options.mockBody, options, req, res);
+      return;
+    }
+
+    if (!options.mockFile) {
+      const status = options.httpStatus || 404;
+      res.status(status).send();
       return;
     }
 

--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -261,6 +261,20 @@ apiMocker.fillTemplateSwitch = (options, data) => {
   return filled;
 };
 
+apiMocker.processTemplateData = (data, options, req, res) => { 
+  if (options.templateSwitch) {
+    data = apiMocker.fillTemplateSwitch(options, data, req);
+  }
+
+  if (options.enableTemplate === true) {
+    data = apiMocker.fillTemplate(data, req);
+  }
+
+  const buff = Buffer.from(data, 'utf8');
+
+  res.status(options.httpStatus || 200).send(buff);
+}
+
 apiMocker.sendResponse = (req, res, serviceKeys) => {
   let originalOptions;
   let mockPath;
@@ -300,9 +314,17 @@ apiMocker.sendResponse = (req, res, serviceKeys) => {
       res.set(options.headers);
     }
 
-    if (!options.mockFile) {
+    if (!options.mockFile && !options.mockBody) {
       const status = options.httpStatus || 404;
       res.status(status).send();
+      return;
+    }
+
+    if (!!options.mockBody) {
+      if (options.contentType) {
+        res.set('Content-Type', options.contentType);
+      };
+      apiMocker.processTemplateData(options.mockBody, options, req, res);
       return;
     }
 
@@ -339,18 +361,7 @@ apiMocker.sendResponse = (req, res, serviceKeys) => {
           res.set('Content-Type', options.contentType);
           fs.readFile(mockPath, { encoding: 'utf8' }, (err, data) => {
             if (err) { throw err; }
-            let filled = data.toString();
-            if (options.templateSwitch) {
-              filled = apiMocker.fillTemplateSwitch(options, filled, req);
-            }
-
-            if (options.enableTemplate === true) {
-              filled = apiMocker.fillTemplate(filled, req);
-            }
-
-            const buff = Buffer.from(filled, 'utf8');
-
-            res.status(options.httpStatus || 200).send(buff);
+            apiMocker.processTemplateData(data.toString(), options, req, res);
           });
         } else {
           res.status(options.httpStatus || 200)

--- a/test/test-config.json
+++ b/test/test-config.json
@@ -158,6 +158,16 @@
       "verbs": ["get"],
       "mockFile": "upload-form.html",
       "contentType": "text/html"
+    },
+    "raw": {
+      "mockBody": "{ \"text\" : \"Good Job!\" }",
+      "verbs": ["all"]
+    },
+    "raw/template/:message": {
+      "mockBody": "{ \"text\" : \"@message\" }",
+      "enableTemplate" : true,
+      "contentType": "application/json",
+      "verbs": ["get"]
     }
   }
 }

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -103,6 +103,16 @@ describe('Functional tests using an http client to test "end-to-end": ', () => {
         verifyResponseBody(reqOptions, null, { king: 'greg' }, done);
       });
 
+		  it('Returns correct body data', function(done){
+  			var reqOptions = createHttpReqOptions('/raw');
+			  verifyResponseBody(reqOptions, null, { "text" : "Good Job!" }, done);
+      });
+      
+		  it('Returns correct body data from message', function(done){
+  			var reqOptions = createHttpReqOptions('/raw/template/ATestHashToReturn');
+			  verifyResponseBody(reqOptions, null, { "text" : "ATestHashToReturn" }, done);
+		  });
+
       it('returns correct data for basic post request', (done) => {
         const reqOptions = createHttpReqOptions('/nested/ace');
         reqOptions.method = 'POST';


### PR DESCRIPTION
Please, consider using the proposed addition of direct body message specification in the config file. Namely:
- Ability to specify `mockBody` _instead_ of `mockFile` and provide it's content as response body;
- The provided body is subject to templating in the very same manner as the `mockFile` content is.
