### PR TITLE
Prettify logging

### DIFF
--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console, no-prototype-builtins, comma-dangle */
+/* eslint-disable no-prototype-builtins, comma-dangle */
 const express = require('express');
 const _ = require('underscore');
 const path = require('path');
@@ -10,6 +10,7 @@ const untildify = require('untildify');
 const util = require('util');
 const proxy = require('express-http-proxy');
 const multer = require('multer');
+const { createLogger, createMiddleware } = require('./logger');
 
 const apiMocker = {};
 
@@ -27,19 +28,14 @@ apiMocker.defaults = {
 apiMocker.createServer = (options = {}) => {
   apiMocker.options = Object.assign({}, apiMocker.defaults, options);
 
-  function logger(msg, obj) {
-    if (!options.quiet) {
-      if (obj) {
-        console.log(msg, obj);
-      } else {
-        console.log(msg);
-      }
-    }
-  }
+  const { quiet } = apiMocker.options;
+  const logger = createLogger({ quiet });
+  const loggerMiddleware = createMiddleware({ quiet });
 
   apiMocker.express = express();
   apiMocker.middlewares = [];
 
+  apiMocker.middlewares.push(loggerMiddleware);
   if (options.uploadRoot) {
     apiMocker.middlewares.push(multer({
       storage: multer.diskStorage({
@@ -82,17 +78,17 @@ apiMocker.createServer = (options = {}) => {
   apiMocker.middlewares.push(apiMocker.router);
 
   if (options.proxyURL) {
-    logger(`Proxying to ${options.proxyURL}`);
+    logger.info(`Proxying to ${options.proxyURL}`);
     const proxyOptions = {
-      forwardPath(req) {
-        logger(`Forwarding request: ${req.originalUrl}`);
+      proxyReqPathResolver(req) {
+        logger.info(`Forwarding request: ${req.originalUrl}`);
         return req.originalUrl;
       },
     };
 
     if (options.proxyIntercept) {
       const interceptPath = path.join(process.cwd(), options.proxyIntercept);
-      logger(`Loading proxy intercept from ${interceptPath}`);
+      logger.info(`Loading proxy intercept from ${interceptPath}`);
       // eslint-disable-next-line global-require, import/no-dynamic-require
       proxyOptions.intercept = require(interceptPath);
     }
@@ -106,7 +102,7 @@ apiMocker.createServer = (options = {}) => {
     apiMocker.middlewares.push(proxy(options.proxyURL, proxyOptions));
   }
 
-  apiMocker.log = logger;
+  apiMocker.logger = logger;
   return apiMocker;
 };
 
@@ -125,11 +121,11 @@ apiMocker.setConfigFile = (file) => {
 
 apiMocker.loadConfigFile = () => {
   if (!apiMocker.configFilePath) {
-    apiMocker.log('No config file path set.');
+    apiMocker.logger.warn('No config file path set.');
     return;
   }
 
-  apiMocker.log(`Loading config file: ${apiMocker.configFilePath}`);
+  apiMocker.logger.info(`Loading config file: ${apiMocker.configFilePath}`);
   let newOptions = _.clone(apiMocker.defaults);
   // eslint-disable-next-line global-require, import/no-dynamic-require
   const exportedValue = require(apiMocker.configFilePath);
@@ -142,7 +138,7 @@ apiMocker.loadConfigFile = () => {
   newOptions.mockDirectory = untildify(newOptions.mockDirectory);
   if (newOptions.mockDirectory === '/file/system/path/to/apimocker/samplemocks/') {
     newOptions.mockDirectory = path.join(__dirname, '/../samplemocks');
-    apiMocker.log('Set mockDirectory to: ', newOptions.mockDirectory);
+    apiMocker.logger.info('Set mockDirectory to: ', newOptions.mockDirectory);
   }
   apiMocker.options = newOptions;
 
@@ -167,7 +163,7 @@ apiMocker.createAdminServices = () => {
   apiMocker.router.all('/admin/setMock', (req, res) => {
     let newRoute = {};
     if (req.body.serviceUrl && req.body.verb && req.body.mockFile) {
-      apiMocker.log(`Received JSON request: ${JSON.stringify(req.body)}`);
+      apiMocker.logger.info(`Received JSON request: ${JSON.stringify(req.body)}`);
       newRoute = req.body;
       newRoute.verb = newRoute.verb.toLowerCase();
       newRoute.httpStatus = req.body.httpStatus;
@@ -193,7 +189,7 @@ apiMocker.setRoutes = (webServices) => {
   const topLevelKeys = _.keys(webServices);
   _.each(topLevelKeys, (key) => {
     const svc = _.clone(webServices[key]);
-    // apiMocker.log('about to add a new service: ' + JSON.stringify(svc));
+    // apiMocker.logger.info('about to add a new service: ' + JSON.stringify(svc));
     _.each(svc.verbs, (v) => {
       apiMocker.setRoute(apiMocker.getServiceRoute(key, v));
     });
@@ -250,15 +246,15 @@ apiMocker.fillTemplateSwitch = (options, data) => {
       // Handle unquoted numbers first
       // Search for '"@@key"' in JSON template,
       // replace with value (no double quotes around final value)
-      apiMocker.log(`fillTemplateSwitch -> search for "@@${key}" replace with ${value}`);
+      apiMocker.logger.info(`fillTemplateSwitch -> search for "@@${key}" replace with ${value}`);
       filled = filled.replace(new RegExp(`"@@${key}"`, 'g'), value);
 
       // Handle quoted values second
       // Search for '@key' in JSON template, replace with value
-      apiMocker.log(`fillTemplateSwitch -> search for @${key} replace with ${value}`);
+      apiMocker.logger.info(`fillTemplateSwitch -> search for @${key} replace with ${value}`);
       filled = filled.replace(new RegExp(`@${key}`, 'g'), value);
     } else {
-      apiMocker.log(`fillTemplateSwitch -> skipping search for @${key} with no value.`);
+      apiMocker.logger.info(`fillTemplateSwitch -> skipping search for @${key} with no value.`);
     }
   });
 
@@ -266,8 +262,8 @@ apiMocker.fillTemplateSwitch = (options, data) => {
 };
 
 apiMocker.sendResponse = (req, res, serviceKeys) => {
-  let originalOptions; let
-    mockPath;
+  let originalOptions;
+  let mockPath;
   // we want to look up the service info from our in-memory 'webServices' every time.
   let options = apiMocker.getServiceRoute(serviceKeys.serviceUrl, serviceKeys.verb);
 
@@ -276,7 +272,6 @@ apiMocker.sendResponse = (req, res, serviceKeys) => {
       // express handles these two differently - it strips out body, content-type,
       // and content-length headers.
       // There's no body or content-length, so we just send the status code.
-      apiMocker.log(`Returning http status: ${options.httpStatus}`);
       res.sendStatus(options.httpStatus);
       return;
     }
@@ -287,7 +282,7 @@ apiMocker.sendResponse = (req, res, serviceKeys) => {
       apiMocker.setSwitchOptions(options, req);
       mockPath = path.join(apiMocker.options.mockDirectory, options.mockFile || '');
       if (!fs.existsSync(mockPath)) {
-        apiMocker.log(`No file found: ${options.mockFile} attempting base file: ${originalOptions.mockFile}`);
+        apiMocker.logger.warn(`No file found: ${options.mockFile} attempting base file: ${originalOptions.mockFile}`);
         options.mockFile = originalOptions.mockFile;
       }
     }
@@ -297,8 +292,8 @@ apiMocker.sendResponse = (req, res, serviceKeys) => {
     }
 
     if (apiMocker.options.logRequestHeaders || options.logRequestHeaders) {
-      apiMocker.log('Request headers:');
-      apiMocker.log(req.headers);
+      apiMocker.logger.info('Request headers:');
+      apiMocker.logger.info(req.headers);
     }
 
     if (options.headers) {
@@ -307,10 +302,12 @@ apiMocker.sendResponse = (req, res, serviceKeys) => {
 
     if (!options.mockFile) {
       const status = options.httpStatus || 404;
-      apiMocker.log('No mockFile found.  Returning httpStatus: ', status);
       res.status(status).send();
       return;
     }
+
+    // Add mockFile name for logging
+    res.locals.mockFile = options.mockFile;
 
     if (options.switch && options.jsonPathSwitchResponse) {
       let jpath = options.jsonPathSwitchResponse.jsonpath;
@@ -328,15 +325,13 @@ apiMocker.sendResponse = (req, res, serviceKeys) => {
         const allElems = jp.query(JSON.parse(mockFile), jpath);
         res.status(options.httpStatus || 200).send(forceFirstObject ? allElems[0] : allElems);
       } catch (err) {
-        apiMocker.log(err);
+        apiMocker.logger.error(err);
         res.sendStatus(options.httpStatus || 404);
       }
       return;
     }
 
     mockPath = path.join(apiMocker.options.mockDirectory, options.mockFile);
-    apiMocker.log(`Returning mock: ${options.verb.toUpperCase()} ${options.serviceUrl} : ${
-      options.mockFile}`);
 
     fs.exists(mockPath, (exists) => {
       if (exists) {
@@ -537,7 +532,7 @@ apiMocker.setTemplateSwitchOptions = (options, req) => {
       || !switchObject.hasOwnProperty('type')
       || !switchObject.hasOwnProperty('key')
     ) {
-      apiMocker.log('templateSwitch invalid config: missing switch, type or key property. Aborting templateSwitch for this request.');
+      apiMocker.logger.info('templateSwitch invalid config: missing switch, type or key property. Aborting templateSwitch for this request.');
       return;
     }
 
@@ -579,7 +574,7 @@ apiMocker.setTemplateSwitchOptions = (options, req) => {
       // eslint-disable-next-line no-param-reassign
       options.templateSwitch[s] = switchObject;
     } else {
-      apiMocker.log(`templateSwitch[${switchObject.switch}] value NOT FOUND`);
+      apiMocker.logger.warn(`templateSwitch[${switchObject.switch}] value NOT FOUND`);
     }
   });
 };
@@ -593,14 +588,14 @@ apiMocker.setRoute = (options) => {
   apiMocker.router[options.verb](`/${options.serviceUrl}`, (req, res) => {
     apiMocker.sendResponse(req, res, options);
   });
-  apiMocker.log(`Set route: ${options.verb.toUpperCase()} ${options.serviceUrl} : ${
+  apiMocker.logger.info(`Set route: ${options.verb.toUpperCase()} ${options.serviceUrl} : ${
     displayFile} ${displayLatency}`);
   if (options.switch) {
     let switchDescription = options.switch;
     if (options.switch instanceof Array || options.switch instanceof Object) {
       switchDescription = util.inspect(options.switch);
     }
-    apiMocker.log(` with switch on param: ${switchDescription}`);
+    apiMocker.logger.info(` with switch on param: ${switchDescription}`);
   }
 };
 
@@ -622,7 +617,7 @@ apiMocker.start = (serverPort, callback) => {
 
   apiMocker.middlewares.forEach((mw) => {
     if (mw === apiMocker.router && apiMocker.options.basepath) {
-      apiMocker.log('Using basepath: ', apiMocker.options.basepath);
+      apiMocker.logger.info('Using basepath: ', apiMocker.options.basepath);
       apiMocker.express.use(apiMocker.options.basepath, mw);
     } else {
       apiMocker.express.use(mw);
@@ -630,7 +625,6 @@ apiMocker.start = (serverPort, callback) => {
   });
 
   const port = serverPort || apiMocker.options.port;
-  // console.log(JSON.stringify(apiMocker.options));
   if (apiMocker.options.staticDirectory && apiMocker.options.staticPath) {
     apiMocker.express.use(
       apiMocker.options.staticPath,
@@ -639,7 +633,7 @@ apiMocker.start = (serverPort, callback) => {
   }
 
   apiMocker.expressInstance = apiMocker.express.listen(port, callback);
-  apiMocker.log(`Mock server listening on port ${port}`);
+  apiMocker.logger.info(`Mock server listening on port ${port}`);
   return apiMocker;
 };
 
@@ -648,7 +642,7 @@ apiMocker.stop = (callback) => {
   delete require.cache[require.resolve(apiMocker.configFilePath)];
 
   if (apiMocker.expressInstance) {
-    apiMocker.log('Stopping mock server.');
+    apiMocker.logger.info('Stopping mock server.');
     apiMocker.expressInstance.close(callback);
   }
   return apiMocker;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,49 @@
+const chalk = require('chalk');
+const pkg = require('../package.json');
+
+const prefix = `[${pkg.name}]`;
+const colors = {
+  info: chalk.gray,
+  warn: chalk.keyword('orange'),
+  error: chalk.red,
+  success: chalk.green,
+};
+
+// eslint-disable-next-line no-console
+const log = (color, ...msg) => console.log(color(prefix), ...msg);
+
+const logger = {
+  info: (...msg) => log(colors.info, ...msg),
+  warn: (...msg) => log(colors.warn, ...msg),
+  error: (...msg) => log(colors.error, ...msg),
+};
+
+const createLogger = ({ quiet }) => new Proxy(logger, {
+  // Silence logger methods by stubbing them out.
+  get: (target, prop) => (quiet ? () => {} : target[prop]),
+});
+
+const createMiddleware = ({ quiet }) => (req, res, next) => {
+  if (!quiet) {
+    const start = Date.now();
+    res.on('finish', () => {
+      const method = req.method.toUpperCase();
+      const url = req.originalUrl;
+      const status = res.statusCode;
+      const mockFile = res.locals.mockFile || '';
+      const responseTime = Date.now() - start;
+
+      if (res.statusCode >= 400) {
+        logger.error(`${chalk.bold(method)} ${url} ⏎ ${colors.error(status)} ${mockFile} - ${responseTime}ms`);
+      } else {
+        logger.info(`${chalk.bold(method)} ${url} ⏎ ${colors.success(status)} ${mockFile} - ${responseTime}ms`);
+      }
+    });
+  }
+  next();
+};
+
+module.exports = {
+  createLogger,
+  createMiddleware,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,7 +119,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -324,7 +323,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -379,7 +377,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -387,8 +384,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
       "version": "0.5.1",
@@ -684,8 +680,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "0.0.21",
@@ -1111,9 +1106,9 @@
       }
     },
     "express-http-proxy": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-1.1.0.tgz",
-      "integrity": "sha1-tTOEKt0VtwIdeNJIyAtTV4p7a6A=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-1.5.0.tgz",
+      "integrity": "sha512-rYXjOj+ldSDZdmCxRDX/7o6Oxtz45sS9l4QTsvqm+ZFxqI5xTA4usMMP4FBrrKTpDPuQkI2YVda+0LvkJhPu7A==",
       "requires": {
         "debug": "^3.0.1",
         "es6-promise": "^4.1.1",
@@ -1681,8 +1676,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -3075,7 +3069,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
   "author": "Greg Stroup <gstroup@gmail.com>",
   "dependencies": {
     "body-parser": "1.18.2",
+    "chalk": "^2.4.1",
     "commander": "2.11.0",
     "express": "4.16.2",
-    "express-http-proxy": "1.1.0",
+    "express-http-proxy": "1.5.0",
     "express-xml-bodyparser": "0.3.0",
     "jsonpath": "1.0.0",
     "multer": ">=1.3.1",

--- a/test/test-logger.js
+++ b/test/test-logger.js
@@ -1,0 +1,76 @@
+/* eslint-disable no-unused-expressions, no-console */
+const { expect } = require('chai');
+const sinon = require('sinon');
+const { createLogger, createMiddleware } = require('../lib/logger.js');
+
+describe('unit tests: logger : ', () => {
+  beforeEach(() => {
+    sinon.spy(console, 'log');
+  });
+
+  afterEach(() => {
+    console.log.restore();
+  });
+
+  describe('createLogger', () => {
+    it('logs to the console', () => {
+      const logger = createLogger({ quiet: false });
+      const msg = 'Boba Fett';
+      logger.info(msg);
+      logger.warn(msg);
+      logger.error(msg);
+      expect(console.log.calledThrice).to.be.true;
+      expect(console.log.args[0][1]).to.equal(msg);
+    });
+
+    it('does not log when quiet', () => {
+      const logger = createLogger({ quiet: true });
+      const msg = 'Greedo';
+      logger.info(msg);
+      logger.warn(msg);
+      logger.error(msg);
+      expect(console.log.called).to.be.false;
+    });
+  });
+
+  describe('createMiddleware', () => {
+    const req = {
+      method: 'POST',
+      originalUrl: 'some/mock/route',
+    };
+
+    const res = {
+      on: (name, cb) => cb(),
+      statusCode: 400,
+      locals: {
+        mockFile: 'foo.json',
+      },
+    };
+
+    it('logs details of mock request and response', () => {
+      const next = sinon.spy();
+      const middleware = createMiddleware({ quiet: false });
+
+      middleware(req, res, next);
+
+      const [, msg] = console.log.args[0];
+      expect(console.log.called).to.be.true;
+      expect(next.called).to.be.true;
+      expect(msg).to.include(req.method);
+      expect(msg).to.include(req.originalUrl);
+      expect(msg).to.include(res.statusCode);
+      expect(msg).to.include(res.locals.mockFile);
+      expect(msg).to.match(/\d+ms/);
+    });
+
+    it('does not log when quiet', () => {
+      const next = sinon.spy();
+      const middleware = createMiddleware({ quiet: true });
+
+      middleware(req, res, next);
+
+      expect(console.log.called).to.be.false;
+      expect(next.called).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
This improves logging by:

* Prefixing log entries to distinguish mocker entries from other output.
* Adds `info`, `warn`, and `error` colored levels to logger.
<img width="187" alt="logging-levels" src="https://user-images.githubusercontent.com/101895/49454938-15a61e80-f79b-11e8-83d7-8e8bbabe2730.png">

* More consistently log information for mock responses using middleware.
<img width="443" alt="logging-error-response" src="https://user-images.githubusercontent.com/101895/49454959-1f2f8680-f79b-11e8-81f3-6afb88c18455.png">
<img width="395" alt="logging-request-success" src="https://user-images.githubusercontent.com/101895/49454971-25bdfe00-f79b-11e8-8cf3-026a51751073.png">

This is an implementation for issue #92

