### PR TITLE
Added body filtering based on raw body, or provided hash.

### DIFF
--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -278,8 +278,8 @@ apiMocker.sendResponse = (req, res, serviceKeys) => {
     }
 
     // Filter whether the raw body is what we're expecting, if such filter is provided.
-    if (!!options.bodies) {
-      if (!_.find(options.bodies, (filterDef) => apiMocker.compareHashed(filterDef, req.rawBody))) {
+    if (!!options.bodies && !!options.bodies[req.method.toLowerCase()]) {
+      if (!_.find(options.bodies[req.method.toLowerCase()], (filterDef) => apiMocker.compareHashed(filterDef, req.rawBody))) {
         res.status(404).send();
         return;
       }

--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -632,7 +632,7 @@ apiMocker.compareHashed = (filterDef, body) => {
     hasher.update(body);
     const digest = hasher.digest('hex');
     apiMocker.logger.warn(`Body hash ${algo}: ${digest}`);
-    return digest == filterDef[algo];
+    return digest.toLowerCase() == filterDef[algo].toLowerCase();
   }
 };
 

--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -279,7 +279,9 @@ apiMocker.sendResponse = (req, res, serviceKeys) => {
 
     // Filter whether the raw body is what we're expecting, if such filter is provided.
     if (!!options.bodies && !!options.bodies[req.method.toLowerCase()]) {
-      if (!_.find(options.bodies[req.method.toLowerCase()], (filterDef) => apiMocker.compareHashed(filterDef, req.rawBody))) {
+      if (!_.find(options.bodies[req.method.toLowerCase()], 
+          (filterDef) => apiMocker.compareHashed(filterDef, req.rawBody || JSON.stringify(req.body)))) 
+      {
         res.status(404).send();
         return;
       }

--- a/lib/apimocker.js
+++ b/lib/apimocker.js
@@ -10,6 +10,7 @@ const untildify = require('untildify');
 const util = require('util');
 const proxy = require('express-http-proxy');
 const multer = require('multer');
+const crypto = require('crypto');
 const { createLogger, createMiddleware } = require('./logger');
 
 const apiMocker = {};
@@ -48,7 +49,7 @@ apiMocker.createServer = (options = {}) => {
   }
 
   let saveBody;
-  if (options.proxyURL) {
+  if (options.proxyURL || options.allowAvoidPreFlight) {
     saveBody = (req, res, buf) => {
       req.rawBody = buf;
     };
@@ -274,6 +275,14 @@ apiMocker.sendResponse = (req, res, serviceKeys) => {
       // There's no body or content-length, so we just send the status code.
       res.sendStatus(options.httpStatus);
       return;
+    }
+
+    // Filter whether the raw body is what we're expecting, if such filter is provided.
+    if (!!options.bodies) {
+      if (!_.find(options.bodies, (filterDef) => apiMocker.compareHashed(filterDef, req.rawBody))) {
+        res.status(404).send();
+        return;
+      }
     }
 
     if (options.switch && !options.jsonPathSwitchResponse) {
@@ -609,6 +618,20 @@ apiMocker.corsMiddleware = (req, res, next) => {
   res.set('Access-Control-Allow-Credentials', credentials);
 
   next();
+};
+
+apiMocker.compareHashed = (filterDef, body) => {
+  if (!(filterDef instanceof Object)) {
+    return filterDef == body;
+  }
+  else {
+    const algo = _.keys(filterDef)[0];
+    const hasher = crypto.createHash(algo);
+    hasher.update(body);
+    const digest = hasher.digest('hex');
+    apiMocker.logger.warn(`Body hash ${algo}: ${digest}`);
+    return digest == filterDef[algo];
+  }
 };
 
 apiMocker.start = (serverPort, callback) => {

--- a/test/test-config.json
+++ b/test/test-config.json
@@ -161,10 +161,10 @@
     },
     "body/filter": {
       "verbs": ["post"],
-      "bodies": [
+      "bodies": { "post": [
         "{ \"text\": \"Raw body filter test\" }",
         { "sha1": "46607ed90dbc35ffa40bf49db6e341e92487f2bc" }
-      ],
+      ]},
       "mockFile": "king.json"
     }
   }

--- a/test/test-config.json
+++ b/test/test-config.json
@@ -158,6 +158,14 @@
       "verbs": ["get"],
       "mockFile": "upload-form.html",
       "contentType": "text/html"
+    },
+    "body/filter": {
+      "verbs": ["post"],
+      "bodies": [
+        "{ \"text\": \"Raw body filter test\" }",
+        { "sha1": "46607ed90dbc35ffa40bf49db6e341e92487f2bc" }
+      ],
+      "mockFile": "king.json"
     }
   }
 }


### PR DESCRIPTION
In certain condition, it would help to be able to filter mock responses, based on the provided body content - without bothering to inspect all parsed values (switches), or even when the body is not parsable at all.

In order to be able to handle complex and/or big bodies, comparing against its hash is provided as an option. The (matching) hash is provided in the mock configuration and when a request comes, the actual body's hash is compared against it. All hashing algorithms provided by `crypto` module are usable.